### PR TITLE
Locate label by class within the placeholder

### DIFF
--- a/src/Gauge.js
+++ b/src/Gauge.js
@@ -568,7 +568,7 @@
          * @param  {Number} [a] the angle of the value drawn
          */
         function drawText(x, y, id, text, textOptions, a) {
-            var span = $("#" + id);
+            var span = $("." + id, placeholder);
             var exists = span.length;
             if (!exists) {
                 span = $("<span></span>")


### PR DESCRIPTION
By using global IDs it was impossible to use the gauge on more than one
graph canvas as the labels of the first would be reused and modified
